### PR TITLE
Fix 10 bugs across content.js, popup.js, and background.js

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -25,7 +25,7 @@ chrome.runtime.onInstalled.addListener(function () {
             "assignments_due": true,
             "gpa_calc": false,
             "dark_mode": true,
-            "gradent_cards": false,
+            "gradient_cards": false,
             "disable_color_overlay": false,
             "auto_dark": false,
             "auto_dark_start": { "hour": "20", "minute": "00" },

--- a/js/content.js
+++ b/js/content.js
@@ -96,6 +96,7 @@ async function insertReminders(reminders) {
             if (insert.c === -1 && insert.h === storage["reminders"][i].h) {
                 overrides = true;
                 storage["reminders"][i] = insert;
+                found = true;
             } else if (insert.h === storage["reminders"][i].h) {
                 found = true;
             }
@@ -146,10 +147,9 @@ async function reminderWatch() {
     const alertPeriod2 = 1000 * 60 * 60 * 2; // 2 hours
     const storage = await chrome.storage.sync.get(["reminders", "reminder_count"]);
     const now = (new Date()).getTime();
-    storage["reminders"].forEach((reminder, index) => {
-        if (reminder.d < now) {
-            storage["reminders"].splice(index, 1);
-        } else if ((reminder.c == 0 && reminder.d < now + alertPeriod) || (reminder.c == 1 && reminder.d < now + alertPeriod2)) {
+    storage["reminders"] = storage["reminders"].filter(reminder => reminder.d >= now);
+    storage["reminders"].forEach(reminder => {
+        if ((reminder.c == 0 && reminder.d < now + alertPeriod) || (reminder.c == 1 && reminder.d < now + alertPeriod2)) {
             createReminder(reminder, container);
         }
     });
@@ -420,11 +420,11 @@ function inspectDarkMode(withOutput = false) {
             }
             */
             if (r > 245 && g > 245 && b > 245 && !(r === bg0.r && g === bg0.g && b === bg0.b) && !(r === lnk.r && g === lnk.g && b === lnk.b)) {
-                el.style.cssText = (";background:" + options.dark_preset["background-0"] + "!important;color" + options.dark_preset["text-0"] + "!important;") + el.style.cssText;
+                el.style.cssText = (";background:" + options.dark_preset["background-0"] + "!important;color:" + options.dark_preset["text-0"] + "!important;") + el.style.cssText;
                 if (withOutput === true) output += selector + "{background: background-0, color: text-0}\n";
                 bgcount++;
             } else if (r > 225 && r < 245 && g > 225 && g < 245 && b > 225 && b < 245 && !(r === bg1.r && g === bg1.g && b === bg1.b) && !(r === lnk.r && g === lnk.g && b === lnk.b)) {
-                el.style.cssText = (";background:" + options.dark_preset["background-1"] + "!important;color" + options.dark_preset["text-0"] + "!important;") + el.style.cssText;
+                el.style.cssText = (";background:" + options.dark_preset["background-1"] + "!important;color:" + options.dark_preset["text-0"] + "!important;") + el.style.cssText;
                 if (withOutput === true) output += selector + "{background: background-1, color: text-0}";
                 bgcount++;
             }
@@ -1114,7 +1114,7 @@ async function changeColorPreset(colors) {
     clearInterval(changeColorInterval);
     const csrfToken = CSRFtoken();
     const delay = 250;
-    previous = []
+    let previous = []
     colorChanges = [];
 
     // sort cards
@@ -1262,7 +1262,7 @@ function autoDarkModeCheck() {
 
 function toggleAutoDarkMode() {
     clearInterval(timeCheck);
-    if (options.auto_dark && options.auto_dark === false) return;
+    if (!options.auto_dark) return;
     autoDarkModeCheck();
     timeCheck = setInterval(autoDarkModeCheck, 60000);
 }
@@ -1286,6 +1286,7 @@ function runiframeChecker() {
         for (const mutation of mutationList) {
             if (mutation.type === 'childList' && mutation.addedNodes.length > 0 && mutation.addedNodes[0].nodeName == "IFRAME") {
                 const frame = mutation.addedNodes[0];
+                if (!frame.contentDocument || !frame.contentDocument.body) continue;
                 const new_style_element = document.createElement("style");
                 new_style_element.textContent = generateDarkModeCSS();
                 new_style_element.id = "darkcss";
@@ -1413,6 +1414,7 @@ function loadCardAssignments() {
         });
         return;
     }
+    if (!cardAssignments) cardAssignments = preloadAssignmentEls();
     cardAssignments.then(els => {
         try {
             let cards = document.querySelectorAll('.ic-DashboardCard');

--- a/js/popup.js
+++ b/js/popup.js
@@ -28,7 +28,7 @@ const defaultOptions = {
         "assignments_due": true,
         "gpa_calc": false,
         "dark_mode": true,
-        "gradent_cards": false,
+        "gradient_cards": false,
         "disable_color_overlay": false,
         "auto_dark": false,
         "auto_dark_start": { "hour": "20", "minute": "00" },
@@ -120,7 +120,7 @@ function displayDarkModeFixUrls() {
                 chrome.storage.sync.get("dark_mode_fix", sync => {
                     for (let i = 0; i < sync["dark_mode_fix"].length; i++) {
                         if (sync["dark_mode_fix"][i] === url) {
-                            sync["dark_mode_fix"].splice(i);
+                            sync["dark_mode_fix"].splice(i, 1);
                             chrome.storage.sync.set({ "dark_mode_fix": sync["dark_mode_fix"] }).then(() => div.remove());
                         }
                     }
@@ -351,8 +351,12 @@ function setup() {
 
     // activate import input box
     document.querySelector("#import-input").addEventListener("input", (e) => {
-        const obj = JSON.parse(e.target.value);
-        importTheme(obj);
+        try {
+            const obj = JSON.parse(e.target.value);
+            importTheme(obj);
+        } catch (err) {
+            // invalid JSON while user is still typing — ignore silently
+        }
     });
 
     // activate export checkbox
@@ -988,7 +992,7 @@ async function displayThemeListNew(direction) {
     if (direction === 1 && current_page_num < maxPage) current_page_num++;
 
     let themes = [];
-    let apiLink = `${current_sort.toLowerCase()}?page=${current_page_num}` + (searchFor === "" ? "" : `&searchFor=${searchFor}`);
+    let apiLink = `${current_sort.toLowerCase()}?page=${current_page_num}` + (searchFor === "" ? "" : `&searchFor=${encodeURIComponent(searchFor)}`);
     if (current_sort === "Liked") {
         const sync = await chrome.storage.sync.get("id");
         const local = await chrome.storage.local.get("liked_themes");
@@ -997,7 +1001,7 @@ async function displayThemeListNew(direction) {
             maxPage = Math.ceil(local["liked_themes"].length / 28);
         } else { // fallback if there is no id
             current_page_num = 1;
-            apiLink = `popular?page=${current_page_num}` + (searchFor === "" ? "" : `&searchFor=${searchFor}`);
+            apiLink = `popular?page=${current_page_num}` + (searchFor === "" ? "" : `&searchFor=${encodeURIComponent(searchFor)}`);
         }
     }
 


### PR DESCRIPTION
- Fix forEach+splice skipping elements in reminderWatch; use filter instead
- Fix missing `found = true` in insertReminders override branch causing duplicate reminders
- Fix missing colon in CSS color property in inspectDarkMode (color#hex → color:#hex)
- Fix impossible guard `auto_dark && auto_dark === false` in toggleAutoDarkMode
- Fix `previous` undeclared variable in changeColorPreset (implicit global)
- Fix cross-origin iframe null contentDocument crash in runiframeChecker
- Fix cardAssignments undefined TypeError on first dashboard load in loadCardAssignments
- Fix splice(i) without deleteCount removing all URLs after index in displayDarkModeFixUrls
- Fix JSON.parse without try/catch crashing import input on invalid JSON
- Fix searchFor not URL-encoded in theme API requests
- Fix "gradent_cards" typo in default options (was orphaning gradient_cards storage key)